### PR TITLE
test: middleware・actions・auth の未テスト分岐にカバレッジを追加

### DIFF
--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InMemoryNotesRepository } from './helpers/in-memory-repository';
+
+const mockRedirect = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockGetRepository = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', () => ({ redirect: mockRedirect }));
+vi.mock('@/lib/auth', () => ({ getCurrentUser: mockGetCurrentUser }));
+vi.mock('@/lib/db', () => ({ getRepository: mockGetRepository }));
+
+import { createNoteAction, updateNoteAction, deleteNoteAction } from '../lib/actions';
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.append(key, value);
+  }
+  return fd;
+}
+
+const INITIAL_STATE = { success: false as const, error: '' };
+
+describe('createNoteAction', () => {
+  let repo: InMemoryNotesRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo = new InMemoryNotesRepository();
+    mockGetRepository.mockResolvedValue(repo);
+  });
+
+  it('未認証 → auth エラーを返却し redirect 未呼び出し', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const fd = makeFormData({ title: 'タイトル', content: '内容' });
+
+    const result = await createNoteAction(INITIAL_STATE, fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeTruthy();
+    }
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('バリデーション失敗（空タイトル）→ エラーを返却', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+    const fd = makeFormData({ title: '', content: '内容' });
+
+    const result = await createNoteAction(INITIAL_STATE, fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeTruthy();
+    }
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('成功 → redirect("/") を呼び出す', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+    const fd = makeFormData({ title: '新しいノート', content: '本文' });
+
+    const result = await createNoteAction(INITIAL_STATE, fd);
+
+    expect(result.success).toBe(true);
+    expect(mockRedirect).toHaveBeenCalledWith('/');
+  });
+
+  it('FormData から title と content を正しく取得する', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+    const fd = makeFormData({ title: '正確なタイトル', content: '正確な内容' });
+
+    await createNoteAction(INITIAL_STATE, fd);
+
+    const saved = (await repo.getAllNotes())[0];
+    expect(saved?.title).toBe('正確なタイトル');
+    expect(saved?.content).toBe('正確な内容');
+  });
+});
+
+describe('updateNoteAction', () => {
+  let repo: InMemoryNotesRepository;
+  let existingNoteId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    repo = new InMemoryNotesRepository();
+    const note = await repo.createNote({ title: '既存ノート', content: '既存内容' });
+    existingNoteId = note.id;
+    mockGetRepository.mockResolvedValue(repo);
+  });
+
+  it('未認証 → auth エラーを返却し redirect 未呼び出し', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const fd = makeFormData({ id: existingNoteId, title: '更新', content: '更新内容' });
+
+    const result = await updateNoteAction(INITIAL_STATE, fd);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeTruthy();
+    }
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('バリデーション失敗（空タイトル）→ エラーを返却', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+    const fd = makeFormData({ id: existingNoteId, title: '', content: '内容' });
+
+    const result = await updateNoteAction(INITIAL_STATE, fd);
+
+    expect(result.success).toBe(false);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('成功 → redirect("/notes/:id") を呼び出す', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+    const fd = makeFormData({ id: existingNoteId, title: '更新タイトル', content: '更新内容' });
+
+    const result = await updateNoteAction(INITIAL_STATE, fd);
+
+    expect(result.success).toBe(true);
+    expect(mockRedirect).toHaveBeenCalledWith(`/notes/${existingNoteId}`);
+  });
+
+  it('FormData から id / title / content を正しく取得する', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+    const fd = makeFormData({ id: existingNoteId, title: '正確な更新', content: '正確な内容' });
+
+    await updateNoteAction(INITIAL_STATE, fd);
+
+    const updated = await repo.getNoteById(existingNoteId);
+    expect(updated?.title).toBe('正確な更新');
+    expect(updated?.content).toBe('正確な内容');
+  });
+});
+
+describe('deleteNoteAction', () => {
+  let repo: InMemoryNotesRepository;
+  let existingNoteId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    repo = new InMemoryNotesRepository();
+    const note = await repo.createNote({ title: '削除対象', content: '内容' });
+    existingNoteId = note.id;
+    mockGetRepository.mockResolvedValue(repo);
+  });
+
+  it('未認証 → auth エラーを返却', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+
+    const result = await deleteNoteAction(existingNoteId);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeTruthy();
+    }
+  });
+
+  it('成功 → { success: true, noteId } を返却（redirect なし）', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+
+    const result = await deleteNoteAction(existingNoteId);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.noteId).toBe(existingNoteId);
+    }
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('成功後にリポジトリからノートが削除される', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1' });
+
+    await deleteNoteAction(existingNoteId);
+
+    const deleted = await repo.getNoteById(existingNoteId);
+    expect(deleted).toBeNull();
+  });
+});

--- a/__tests__/auth-actions.test.ts
+++ b/__tests__/auth-actions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockHeadersGet = vi.hoisted(() => vi.fn());
+const mockHeaders = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ get: mockHeadersGet })
+);
+
+const mockSignInWithOAuth = vi.hoisted(() => vi.fn());
+const mockSignOut = vi.hoisted(() => vi.fn());
+const mockCreateSupabaseServerClient = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    auth: {
+      signInWithOAuth: mockSignInWithOAuth,
+      signOut: mockSignOut,
+    },
+  })
+);
+
+const mockRedirect = vi.hoisted(() => vi.fn());
+
+vi.mock('next/headers', () => ({ headers: mockHeaders }));
+vi.mock('@/lib/supabase/server', () => ({
+  createSupabaseServerClient: mockCreateSupabaseServerClient,
+}));
+vi.mock('next/navigation', () => ({ redirect: mockRedirect }));
+
+import { signInWithGoogle, signOutAction } from '../lib/auth-actions';
+
+describe('signInWithGoogle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSupabaseServerClient.mockResolvedValue({
+      auth: {
+        signInWithOAuth: mockSignInWithOAuth,
+        signOut: mockSignOut,
+      },
+    });
+    // デフォルト: origin ヘッダーあり
+    mockHeadersGet.mockImplementation((key: string) => {
+      if (key === 'origin') return 'https://example.com';
+      return null;
+    });
+  });
+
+  it('OAuth エラー → /login?error=auth_failed へリダイレクト', async () => {
+    mockSignInWithOAuth.mockResolvedValue({
+      data: { url: null },
+      error: new Error('oauth error'),
+    });
+
+    await signInWithGoogle();
+
+    expect(mockRedirect).toHaveBeenCalledWith('/login?error=auth_failed');
+  });
+
+  it('data.url が null → /login?error=auth_failed へリダイレクト', async () => {
+    mockSignInWithOAuth.mockResolvedValue({
+      data: { url: null },
+      error: null,
+    });
+
+    await signInWithGoogle();
+
+    expect(mockRedirect).toHaveBeenCalledWith('/login?error=auth_failed');
+  });
+
+  it('成功 → OAuth URL へリダイレクト', async () => {
+    const oauthUrl = 'https://accounts.google.com/o/oauth2/auth?...';
+    mockSignInWithOAuth.mockResolvedValue({
+      data: { url: oauthUrl },
+      error: null,
+    });
+
+    await signInWithGoogle();
+
+    expect(mockRedirect).toHaveBeenCalledWith(oauthUrl);
+  });
+
+  it('origin ヘッダーなし → host ヘッダーで redirectTo を構築', async () => {
+    mockHeadersGet.mockImplementation((key: string) => {
+      if (key === 'host') return 'myapp.example.com';
+      return null; // origin は null
+    });
+    mockSignInWithOAuth.mockResolvedValue({
+      data: { url: 'https://accounts.google.com/o/oauth2/auth' },
+      error: null,
+    });
+
+    await signInWithGoogle();
+
+    const callArg = mockSignInWithOAuth.mock.calls[0]?.[0] as {
+      options: { redirectTo: string };
+    };
+    expect(callArg.options.redirectTo).toBe('https://myapp.example.com/auth/callback');
+  });
+});
+
+describe('signOutAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSupabaseServerClient.mockResolvedValue({
+      auth: {
+        signInWithOAuth: mockSignInWithOAuth,
+        signOut: mockSignOut,
+      },
+    });
+  });
+
+  it('signOut を呼び出して / へリダイレクト', async () => {
+    mockSignOut.mockResolvedValue({});
+
+    await signOutAction();
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockRedirect).toHaveBeenCalledWith('/');
+  });
+});

--- a/__tests__/auth-callback.test.ts
+++ b/__tests__/auth-callback.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExchangeCodeForSession = vi.hoisted(() => vi.fn());
+const mockCreateSupabaseServerClient = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    auth: { exchangeCodeForSession: mockExchangeCodeForSession },
+  })
+);
+
+vi.mock('@/lib/supabase/server', () => ({
+  createSupabaseServerClient: mockCreateSupabaseServerClient,
+}));
+
+import { GET } from '../app/auth/callback/route';
+
+describe('GET /auth/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSupabaseServerClient.mockResolvedValue({
+      auth: { exchangeCodeForSession: mockExchangeCodeForSession },
+    });
+  });
+
+  it('code なし → / へリダイレクト', async () => {
+    const request = new Request('http://localhost/auth/callback');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/');
+  });
+
+  it('code なし → exchangeCodeForSession が呼び出されない', async () => {
+    const request = new Request('http://localhost/auth/callback');
+
+    await GET(request);
+
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it('code あり + 交換成功 → / へリダイレクト', async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+    const request = new Request('http://localhost/auth/callback?code=valid-code');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/');
+  });
+
+  it('code あり + 交換失敗 → /login?error=auth_failed へリダイレクト', async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: new Error('invalid code') });
+    const request = new Request('http://localhost/auth/callback?code=bad-code');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/login?error=auth_failed');
+  });
+});

--- a/__tests__/env.test.ts
+++ b/__tests__/env.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetCloudflareContext = vi.hoisted(() => vi.fn());
+
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: mockGetCloudflareContext,
+}));
+
+import { getSupabaseRuntimeEnv } from '../lib/env';
+
+const VALID_CF_ENV = {
+  SUPABASE_URL: 'https://cf.supabase.co',
+  SUPABASE_ANON_KEY: 'cf-anon-key',
+};
+
+describe('getSupabaseRuntimeEnv', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    mockGetCloudflareContext.mockReset();
+    // process.env の値を確実に消す
+    process.env.SUPABASE_URL = '';
+    process.env.SUPABASE_ANON_KEY = '';
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('CF context が有効 → CF env を返す', async () => {
+    mockGetCloudflareContext.mockResolvedValue({ env: VALID_CF_ENV });
+
+    const result = await getSupabaseRuntimeEnv();
+
+    expect(result.SUPABASE_URL).toBe(VALID_CF_ENV.SUPABASE_URL);
+    expect(result.SUPABASE_ANON_KEY).toBe(VALID_CF_ENV.SUPABASE_ANON_KEY);
+  });
+
+  it('CF context が throw → process.env にフォールバック', async () => {
+    mockGetCloudflareContext.mockRejectedValue(new Error('CF not available'));
+    vi.stubEnv('SUPABASE_URL', 'https://process.supabase.co');
+    vi.stubEnv('SUPABASE_ANON_KEY', 'process-anon-key');
+
+    const result = await getSupabaseRuntimeEnv();
+
+    expect(result.SUPABASE_URL).toBe('https://process.supabase.co');
+    expect(result.SUPABASE_ANON_KEY).toBe('process-anon-key');
+  });
+
+  it('CF env の SUPABASE_URL が空文字 → process.env にフォールバック', async () => {
+    mockGetCloudflareContext.mockResolvedValue({
+      env: { SUPABASE_URL: '', SUPABASE_ANON_KEY: 'cf-key' },
+    });
+    vi.stubEnv('SUPABASE_URL', 'https://process.supabase.co');
+    vi.stubEnv('SUPABASE_ANON_KEY', 'process-anon-key');
+
+    const result = await getSupabaseRuntimeEnv();
+
+    expect(result.SUPABASE_URL).toBe('https://process.supabase.co');
+  });
+
+  it('CF env が両方空文字 → process.env にフォールバック', async () => {
+    mockGetCloudflareContext.mockResolvedValue({
+      env: { SUPABASE_URL: '', SUPABASE_ANON_KEY: '' },
+    });
+    vi.stubEnv('SUPABASE_URL', 'https://process.supabase.co');
+    vi.stubEnv('SUPABASE_ANON_KEY', 'process-anon-key');
+
+    const result = await getSupabaseRuntimeEnv();
+
+    expect(result.SUPABASE_URL).toBe('https://process.supabase.co');
+    expect(result.SUPABASE_ANON_KEY).toBe('process-anon-key');
+  });
+
+  it('CF も process.env も無効 → エラーをスロー', async () => {
+    mockGetCloudflareContext.mockRejectedValue(new Error('CF not available'));
+    // process.env は beforeEach で空文字にクリア済み
+
+    await expect(getSupabaseRuntimeEnv()).rejects.toThrow();
+  });
+
+  it('SUPABASE_URL のみ未設定 → エラーをスロー', async () => {
+    mockGetCloudflareContext.mockRejectedValue(new Error('CF not available'));
+    vi.stubEnv('SUPABASE_ANON_KEY', 'process-anon-key');
+    // SUPABASE_URL は設定しない
+
+    await expect(getSupabaseRuntimeEnv()).rejects.toThrow();
+  });
+
+  it('SUPABASE_ANON_KEY のみ未設定 → エラーをスロー', async () => {
+    mockGetCloudflareContext.mockRejectedValue(new Error('CF not available'));
+    vi.stubEnv('SUPABASE_URL', 'https://process.supabase.co');
+    // SUPABASE_ANON_KEY は設定しない
+
+    await expect(getSupabaseRuntimeEnv()).rejects.toThrow();
+  });
+});

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetUser = vi.hoisted(() => vi.fn());
+const mockCreateServerClient = vi.hoisted(() =>
+  vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+  }))
+);
+const mockGetSupabaseRuntimeEnv = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    SUPABASE_URL: 'https://test.supabase.co',
+    SUPABASE_ANON_KEY: 'test-anon-key',
+  })
+);
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: mockCreateServerClient,
+}));
+
+vi.mock('@/lib/env', () => ({
+  getSupabaseRuntimeEnv: mockGetSupabaseRuntimeEnv,
+}));
+
+import { middleware } from '../middleware';
+
+describe('middleware ルート保護', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSupabaseRuntimeEnv.mockResolvedValue({
+      SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_ANON_KEY: 'test-anon-key',
+    });
+    mockCreateServerClient.mockImplementation(() => ({
+      auth: { getUser: mockGetUser },
+    }));
+  });
+
+  describe('未認証ユーザー', () => {
+    beforeEach(() => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+    });
+
+    it('/notes/new へのアクセス → /login にリダイレクト', async () => {
+      const request = new NextRequest('http://localhost/notes/new');
+
+      const response = await middleware(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe('http://localhost/login');
+    });
+
+    it('/notes/:id/edit へのアクセス → /login にリダイレクト', async () => {
+      const request = new NextRequest('http://localhost/notes/abc-123/edit');
+
+      const response = await middleware(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe('http://localhost/login');
+    });
+
+    it('/ へのアクセス → リダイレクトしない', async () => {
+      const request = new NextRequest('http://localhost/');
+
+      const response = await middleware(request);
+
+      expect(response.status).not.toBe(307);
+    });
+
+    it('/notes/:id（詳細）へのアクセス → リダイレクトしない', async () => {
+      const request = new NextRequest('http://localhost/notes/abc-123');
+
+      const response = await middleware(request);
+
+      expect(response.status).not.toBe(307);
+    });
+
+    it('/login へのアクセス → リダイレクトしない', async () => {
+      const request = new NextRequest('http://localhost/login');
+
+      const response = await middleware(request);
+
+      expect(response.status).not.toBe(307);
+    });
+  });
+
+  describe('認証済みユーザー', () => {
+    beforeEach(() => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1', email: 'user@example.com' } } });
+    });
+
+    it('/notes/new へのアクセス → リダイレクトしない', async () => {
+      const request = new NextRequest('http://localhost/notes/new');
+
+      const response = await middleware(request);
+
+      expect(response.status).not.toBe(307);
+    });
+
+    it('/notes/:id/edit へのアクセス → リダイレクトしない', async () => {
+      const request = new NextRequest('http://localhost/notes/abc-123/edit');
+
+      const response = await middleware(request);
+
+      expect(response.status).not.toBe(307);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^2.1.8",
         "autoprefixer": "^10.4.20",
         "esbuild": "^0.27.3",
         "eslint": "^9",
@@ -50,6 +51,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1489,15 +1515,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1509,6 +1560,27 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
@@ -2906,6 +2978,63 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3772,6 +3901,17 @@
       "peerDependencies": {
         "next": "~15.0.8 || ~15.1.12 || ~15.2.9 || ~15.3.9 || ~15.4.11 || ~15.5.10 || ~16.0.11 || ^16.1.5",
         "wrangler": "^4.59.2"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -5812,6 +5952,39 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -7411,6 +7584,13 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/eciesjs": {
@@ -9417,15 +9597,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/glob/node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -9642,6 +9813,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -10011,6 +10189,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -10302,6 +10490,71 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -10318,6 +10571,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -10662,6 +10931,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-table": {
@@ -11644,12 +11941,12 @@
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp": {
@@ -13512,6 +13809,76 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -13643,6 +14010,20 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13906,6 +14287,69 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -15146,6 +15590,110 @@
         "@speed-highlight/core": "^1.2.7",
         "cookie": "^1.0.2",
         "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "lint": "next lint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opennextjs/cloudflare": "^1.16.5",
@@ -40,6 +41,7 @@
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5",
+    "@vitest/coverage-v8": "^2.1.8",
     "vitest": "^2.1.8",
     "wrangler": "^4.59.2"
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['lib/**/*.ts', 'middleware.ts', 'app/**/*.ts'],
+      exclude: ['lib/types.ts'],
+    },
   },
   resolve: {
     alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,14 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
-      include: ['lib/**/*.ts', 'middleware.ts', 'app/**/*.ts'],
-      exclude: ['lib/types.ts'],
+      all: true,
+      include: [
+        'lib/**/*.{ts,tsx}',
+        'app/**/*.{ts,tsx}',
+        'components/**/*.{ts,tsx}',
+        'middleware.ts',
+      ],
+      exclude: ['lib/types.ts', '**/*.d.ts', '**/*.test.*', '**/__tests__/**'],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

- `lib/env.ts`・`lib/actions.ts`・`middleware.ts`・`app/auth/callback/route.ts`・`lib/auth-actions.ts` のセキュリティ上重要な分岐を網羅するテストを追加
- テスト総数 **44 → 78件**（+34件）
- `@vitest/coverage-v8` を導入し `npm run test:coverage` でカバレッジ計測が可能に

## 追加テストファイル

| ファイル | 件数 | カバレッジ |
|---------|-----|-----------|
| `__tests__/env.test.ts` | 7件 | `lib/env.ts` → 100% |
| `__tests__/actions.test.ts` | 11件 | `lib/actions.ts` → 100% |
| `__tests__/middleware.test.ts` | 7件 | `middleware.ts` branch 100% |
| `__tests__/auth-callback.test.ts` | 4件 | `app/auth/callback/route.ts` → 100% |
| `__tests__/auth-actions.test.ts` | 5件 | `lib/auth-actions.ts` → 100% |

## Test plan

- [x] `npm test` — 78/78 全件通過
- [x] `npm run test:coverage` — カバレッジレポート出力確認
- [ ] 既存テスト（44件）がすべて引き続き通ることをレビュー時に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)